### PR TITLE
Added backwards compatible keyword arg to __init__

### DIFF
--- a/bobcatpy.py
+++ b/bobcatpy.py
@@ -21,6 +21,7 @@ class Bobcat:
     def __init__(self,
                  miner_ip='',
                  get_timeout=5,
+                 auto_connect=True
                  ):
         """Init the Bobcat object
 
@@ -28,7 +29,8 @@ class Bobcat:
         """
         self.miner_ip = miner_ip
         self.get_timeout = get_timeout
-        if self.ping() != 0:
+
+        if auto_connect and self.ping() != 0:
             print("[-] Miner not responding or not connected to the network")
 
     def ping(self):


### PR DESCRIPTION
 this bool tests ping() on init of object.

This is undesirable if the caller is taking care of validation / calling ping() directly. Also has side effect of raising exception if the hostname doesnt resolve.

This will be used in my PR (to come) for the HA plugin using this.