### PR TITLE
miner container created timestamp should be epoch timestamp.

### DIFF
--- a/bobcatpy.py
+++ b/bobcatpy.py
@@ -68,7 +68,7 @@ class Bobcat:
                 summary['image_version'] = summary['image'].split(':', 1)[1] if ':' in summary['image'] else None
                 summary['animal'] = miner_status['animal']
                 summary['state'] = miner_status['miner']['State']
-                summary['created'] = self._parse_created(miner_status['miner']['Created'])
+                summary['created'] = miner_status['miner']['Created']
                 summary['miner_height'] = int(miner_status['miner_height'])
                 summary['blockchain_height'] = self.blockchain_height()
                 summary['public_ip'] = miner_status['public_ip']
@@ -80,13 +80,6 @@ class Bobcat:
             logger.error('Exception during status update: %s', ex)
 
         return summary
-
-    def _parse_created(self, created):
-        """Convert miner created epoch timestamp to python datetime object"""
-        if created:
-            return datetime.fromtimestamp(created, tz=timezone.utc)
-
-        return None
 
     def _parse_temperature(self, temperature_string):
         """Parse the temperature value from temperature value string"""


### PR DESCRIPTION
It doesnt make much sense to pass a Python date object in json output.
Instead, we pass the epoch timestamp so that any external application
interacting with bobcatpy can parse the data as needed.